### PR TITLE
Feat/v1.0.1

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,67 @@
+// Background script for GitHub HCP Terraform Plan Formatter
+// Handles badge display when extension processes Terraform plans
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'updateBadge') {
+    const tabId = sender.tab.id;
+    const count = message.count;
+
+    if (count > 0) {
+      // Show badge with count
+      chrome.action.setBadgeText({
+        text: count.toString(),
+        tabId: tabId
+      });
+
+      // Set badge background color (green for successful processing)
+      chrome.action.setBadgeBackgroundColor({
+        color: '#4CAF50',
+        tabId: tabId
+      });
+
+      // Set badge title for tooltip
+      chrome.action.setTitle({
+        title: `GitHub HCP Terraform Plan Formatter - ${count} plan(s) formatted`,
+        tabId: tabId
+      });
+    } else {
+      // Clear badge if no plans processed
+      chrome.action.setBadgeText({
+        text: '',
+        tabId: tabId
+      });
+
+      chrome.action.setTitle({
+        title: 'GitHub HCP Terraform Plan Formatter',
+        tabId: tabId
+      });
+    }
+  }
+});
+
+// Clear badge when tab is updated (page navigation)
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'loading' && tab.url && tab.url.includes('github.com')) {
+    chrome.action.setBadgeText({
+      text: '',
+      tabId: tabId
+    });
+
+    chrome.action.setTitle({
+      title: 'GitHub HCP Terraform Plan Formatter',
+      tabId: tabId
+    });
+  }
+});
+
+// Clear badge when tab becomes active
+chrome.tabs.onActivated.addListener((activeInfo) => {
+  chrome.tabs.get(activeInfo.tabId, (tab) => {
+    if (tab.url && !tab.url.includes('github.com')) {
+      chrome.action.setBadgeText({
+        text: '',
+        tabId: activeInfo.tabId
+      });
+    }
+  });
+});

--- a/build-extension.sh
+++ b/build-extension.sh
@@ -20,6 +20,7 @@ mkdir -p "$BUILD_DIR" "$DIST_DIR"
 # Copy necessary files
 echo "Copying files..."
 cp manifest.json "$BUILD_DIR/"
+cp background.js "$BUILD_DIR/" 2>/dev/null || true
 cp content.js "$BUILD_DIR/" 2>/dev/null || true
 cp style.css "$BUILD_DIR/" 2>/dev/null || true
 cp -r icons/ "$BUILD_DIR/" 2>/dev/null || true

--- a/content.js
+++ b/content.js
@@ -211,6 +211,14 @@
       });
     });
 
+    // Send message to background script to update badge
+    if (processed > 0) {
+      chrome.runtime.sendMessage({
+        type: 'updateBadge',
+        count: processed
+      });
+    }
+
   }
 
   function handlePageLoadOrTransition() {

--- a/content.js
+++ b/content.js
@@ -32,8 +32,7 @@
           return;
         }
 
-        // Only process elements that contain both workspace name and plan
-        if (el.textContent && el.textContent.includes('Terraform Cloud/') && el.textContent.includes('Terraform plan:')) {
+        if (el.textContent && (el.textContent.includes('Terraform plan:') || el.textContent.includes('Terraform Cloud/'))) {
           let text = el.textContent;
           const originalHTML = el.innerHTML;
 
@@ -48,18 +47,13 @@
 
             if (spanMatch && spanMatch[2]) {
               workspaceDisplayName = spanMatch[2].trim();
-              console.log('Debug - Extracted from span:', workspaceDisplayName);
             } else if (linkTextMatch && linkTextMatch[2]) {
               workspaceDisplayName = linkTextMatch[2].trim();
-              console.log('Debug - Extracted from link text:', workspaceDisplayName);
             }
           }
 
           // If not found in HTML, try text patterns
           if (!workspaceDisplayName) {
-            // Debug: log the original text
-            console.log('Debug - Original text:', text);
-
             // Try multiple patterns to extract workspace name
             const patterns = [
               /Terraform Cloud\/([^/]+)\/([^/\s\-—\r\n]+)/,  // More precise pattern to avoid separators
@@ -77,7 +71,6 @@
 
                 // Validate that the workspace name is not empty or just separators
                 if (workspaceDisplayName && !/^[-—\s]*$/.test(workspaceDisplayName)) {
-                  console.log('Debug - Extracted workspace name:', workspaceDisplayName);
                   break;
                 } else {
                   workspaceDisplayName = '';
@@ -95,7 +88,6 @@
                 workspaceDisplayName = pathParts.slice(1).join('/').split(/\s+/)[0];
                 // Remove any separators
                 workspaceDisplayName = workspaceDisplayName.replace(/[-—\s]+.*$/, '');
-                console.log('Debug - Fallback workspace name:', workspaceDisplayName);
               }
             }
           }
@@ -103,7 +95,6 @@
           // Final check: make sure workspace name is not just a separator or invalid
           if (workspaceDisplayName && (/^[-—\s]*$/.test(workspaceDisplayName) || workspaceDisplayName === '—')) {
             workspaceDisplayName = '';
-            console.log('Debug - Rejected invalid workspace name');
           }
 
           // If we still don't have a valid workspace name, try to extract from title attribute
@@ -114,7 +105,6 @@
               const titleWorkspaceMatch = titleContent.match(/Terraform Cloud\/[^/]+\/([^\s]+)/);
               if (titleWorkspaceMatch && titleWorkspaceMatch[1]) {
                 workspaceDisplayName = titleWorkspaceMatch[1].trim();
-                console.log('Debug - Extracted from title:', workspaceDisplayName);
               }
             }
           }
@@ -189,8 +179,6 @@
             } else {
               // For non-link elements, use the extracted workspace name
               const workspaceName = workspaceDisplayName || text.substring(0, text.indexOf('Terraform plan:')).trim();
-
-              console.log('Debug - Final workspace name for display:', workspaceName);
 
               const createColoredSentence = (count, type, action) => {
                 const num = parseInt(count);

--- a/manifest.json
+++ b/manifest.json
@@ -18,8 +18,12 @@
     },
     "default_title": "GitHub HCP Terraform Plan Formatter"
   },
+  "background": {
+    "service_worker": "background.js"
+  },
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "tabs"
   ],
   "host_permissions": [
     "*://github.com/*"

--- a/style.css
+++ b/style.css
@@ -5,6 +5,7 @@
   font-weight: 500;
   line-height: 1.4;
   display: block !important;
+  overflow: visible !important;
 }
 
 .terraform-plan-line {


### PR DESCRIPTION
# 🚀 GitHub HCP Terraform Plan Formatter - Chrome/Edge Extension

## 📋 概要

GitHubのPRページでHCP Terraform planの結果を見やすく整形するChrome/Edge拡張機能です。
長いOrganization名を除去し、重要な変更数値を色分けして表示することで、Terraform planの結果を素早く把握できます。

## ✨ 主な機能

### 🎯 核心機能
- **ワークスペース名の簡潔表示**: `Terraform Cloud/org/workspace-name` → `workspace-name`
- **数値の色分け表示**:
  - 🔵 **Add** (追加): 青色 
  - 🟠 **Change** (変更): オレンジ色
  - 🔴 **Destroy** (削除): 赤色
- **ゼロ以外の数値をハイライト**: 重要な変更を一目で識別

### 🔔 新機能: アクティビティバッジ
- 拡張機能アイコンに処理件数を表示
- 緑色のバッジで正常動作を確認
- ツールチップで詳細情報を表示

## 🔄 表示例

### Before (変更前)