### PR TITLE
refactor: v1.2.0 - text-based detection, HCP Terraform prefix support, SPA navigation fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,24 +14,37 @@ GitHubのPull Requestページで表示されるHCP Terraform（旧Terraform Clo
 ## 技術的課題と解決策
 
 ### 1. 無限ループ問題
-**問題**: textContentの変更がMutationObserverを再発動し、無限ループが発生
-**解決策**: 
+**問題**: DOM書き換えがMutationObserverを再発動し、無限ループが発生
+**解決策**:
 - `data-terraform-formatted="true"`による処理済みマーキング
-- テキスト変更前後の比較チェック
+- 自身が生成した`.terraform-plan-result`内の変更は監視対象から除外
+- debounceタイマーによる実行間引き
 
 ### 2. セレクター問題
-**問題**: GitHubの複雑なCSSモジュール名に依存したセレクターが不安定
-**解決策**: 
-- github-web-cosmetic拡張機能のアプローチを参考
-- 複数セレクターによる包括的検索
-- 属性ベースのセレクター使用
+**問題**: GitHubの複雑なCSSモジュール名に依存したセレクターが不安定（React化された新マージボックス等でクラス名が変わると全滅する）
+**解決策** (v1.2.0):
+- テキストノード走査（TreeWalker）ベースの検出を主軸に変更（セレクター非依存）
+- 既知レイアウト用セレクターは補助ヒントとして維持
+- `<script>`/`<style>`等のタグ内テキストは除外（GitHubの埋め込みJSONペイロードを壊さないために必須）
 
 ### 3. SPA対応
-**問題**: GitHubはSPA（Single Page Application）でページ遷移時にスクリプトが動作しない
-**解決策**:
+**問題**: GitHubはSPA（Turboによるソフト遷移）のため、旧実装（`*/pull/*`のみに注入）では他ページからPRへ遷移した場合にスクリプトが注入されず一切動作しなかった
+**解決策** (v1.2.0):
+- content scriptを`*://github.com/*`全体に注入し、実行時に`/pull/<番号>`のURL判定で処理をゲート
 - turbo:loadイベント対応
 - MutationObserverによる動的コンテンツ監視
-- URL変化検出による再実行
+- URL変化検出による再実行（遷移時にバッジカウントをリセット）
+
+### 4. HCP Terraformリブランド対応 (v1.2.0)
+**問題**: チェック名プレフィックスが`Terraform Cloud/`から`HCP Terraform/`に変わり、旧実装ではマッチしない
+**解決策**: 正規表現で両プレフィックスに対応
+
+### 5. 行全体の破壊防止 (v1.2.0)
+**問題**: `StatusCheckRow`全体をinnerHTML置換すると「Details」リンク等の兄弟要素が消える
+**解決策**:
+- プランサマリーを含む最小要素まで降りてから書き換え（`narrowToSummary`）
+- ワークスペースリンクが兄弟要素の場合は、リンクを保持したままテキストノード単位でプレフィックスのみ削除（`stripProviderPrefix`）
+- 挿入する文字列はすべてHTMLエスケープ
 
 ## 処理フロー
 
@@ -39,74 +52,78 @@ GitHubのPull Requestページで表示されるHCP Terraform（旧Terraform Clo
 1. ページロード/遷移検出
    ├─ turbo:load イベント
    ├─ DOMContentLoaded イベント
-   └─ URL変化検出
+   └─ URL変化検出（MutationObserver内）
 
-2. 要素検索
-   ├─ div.TimelineItem strong (通常GitHub)
-   ├─ ul li div a span (GitHub EMU)
-   ├─ span[class*='titleDescription'] (PRチェック結果)
-   └─ *[class*='StatusCheckRow'] (ステータスチェック行)
+2. 候補要素の収集 (collectCandidates)
+   ├─ 既知セレクター（TimelineItem strong / titleDescription / StatusCheckRow）
+   └─ TreeWalkerによるテキストノード走査（セレクター非依存のフォールバック）
+      └─ script/style/noscript/template/textarea 内は除外
 
-3. テキスト処理
-   ├─ 処理済みチェック (data-terraform-formatted)
-   ├─ Terraform Cloud/<ORG_NAME>/ プレフィックス削除
-   ├─ プラン数値の簡潔化
-   └─ 処理済みマーク付与
+3. 整形 (formatElement)
+   ├─ 処理済みチェック (data-terraform-formatted / .terraform-plan-result)
+   ├─ プランサマリーあり → 最小要素に絞って2行のカラー表示に書き換え
+   │   ├─ "N to add, N to change, N to destroy" → 色付きカウント
+   │   └─ "no changes" → "Terraform plan: No changes"
+   └─ サマリーなし（チェック名リンク等）→ プレフィックスのみ削除
 
 4. イベント監視
-   ├─ MutationObserver (DOM変更)
-   ├─ ボタンクリック検出
+   ├─ MutationObserver (DOM変更、childList + subtree)
    └─ debounceタイマー (過度な実行防止)
 ```
 
-## 参考資料
-
-- **github-web-cosmetic**: `removeCiPrefix()`関数の実装パターンを参考
-- **sample.html**: 実際のGitHub PR HTMLから要素構造を分析
-- **Manifest V3**: 最新のChrome拡張機能仕様に準拠
-
 ## 設定ファイル
 
-### manifest.json
+### manifest.json（要点）
 ```json
 {
   "manifest_version": 3,
-  "permissions": ["activeTab"],
+  "permissions": ["activeTab", "tabs"],
   "host_permissions": ["*://github.com/*"],
   "content_scripts": [{
-    "matches": ["*://github.com/*/pull/*"],
+    "matches": ["*://github.com/*"],
     "js": ["content.js"],
+    "css": ["style.css"],
     "run_at": "document_idle"
   }]
 }
 ```
 
+※ `matches`はPRページ限定ではなくgithub.com全体。SPAソフト遷移対応のため（処理自体はURL判定でPRページのみ実行）。
+
 ## デバッグ情報
 
-コンソールログで以下の情報を確認可能:
-- `🔍 Terraform Formatter: Starting...` - 処理開始
-- `✅ Processed element:` - 要素処理完了
-- `🎯 Processed X Terraform elements` - 処理件数
+コンソール（debugレベル）で以下を確認可能:
+- `🎯 Terraform Plan Formatter: formatted X element(s)` - 処理件数
+
+## 動作検証
+
+`node --check content.js background.js`で構文チェック。
+DOM動作はGitHub風のフィクスチャHTMLをローカルサーバーで`/owner/repo/pull/123`パスとして配信して確認する
+（content.jsはパスに`/pull/<番号>`を含まないと動作しないため、静的ファイルを直接開いても動かない点に注意）。
+検証観点: 旧TimelineItemレイアウト / リンクと説明が兄弟の新レイアウト / no changes /
+Detailsリンクの保持 / 無関係な"No changes"テキストの非破壊 / 埋め込みJSON scriptの非破壊 /
+動的挿入(MutationObserver) / 再実行時の冪等性。
 
 ## 実装済み機能
 
 ### カラー表示機能
-- **Add**: 青色（#3b82f6）、数値>0で強調表示
-- **Change**: オレンジ色（#f59e0b）、数値>0で強調表示  
-- **Destroy**: 赤色（#ef4444）、数値>0で強調表示
-- **ダークモード対応**: システム設定に応じた色調整
+- **Add**: 青色、数値>0で強調表示
+- **Change**: オレンジ色、数値>0で強調表示
+- **Destroy**: 赤色、数値>0で強調表示
+- **ダークモード対応**: システム設定に応じた色調整（style.css）
+
+### バッジ表示（background.js）
+- タブ単位で整形済みプラン数をバッジ表示（ページ内累計、遷移でリセット）
 
 ## 今後の改善案
 
 1. **設定画面追加**: プレフィックス削除の有効/無効切り替え
 2. **カスタムパターン**: ユーザー定義の置換ルール
-3. **他CI対応**: GitHub Actions、Jenkins等への対応拡張
-4. **カラーカスタマイズ**: ユーザー定義の色設定
+3. **カラーカスタマイズ**: ユーザー定義の色設定
+4. **GitHub Enterprise Server対応**: `matches`のホストをオプションで拡張
 
 ## 開発メモ
 
 - 2025-06-29: 初期開発完了
-- 参考拡張機能のアプローチが非常に有効
-- GitHub EMUとの互換性も確保済み
-- 無限ループ対策が重要なポイント
-- HCP Terraform（旧Terraform Cloud）の汎用的対応
+- 2026-07-07: v1.2.0 大規模リファクタリング（テキストベース検出、HCP Terraformプレフィックス対応、SPA遷移対応、最小要素書き換え、HTMLエスケープ、script除外）
+- 無限ループ対策と`<script>`内テキストの除外が重要なポイント

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Terraform plan: 1 to add, 0 to change, 1 to destroy
 
 ## 🎯 Target Pages
 
-- GitHub Pull Request pages: `https://github.com/*/pull/*`
-- Pages with HCP Terraform (formerly Terraform Cloud) check results
+- Injected on all `https://github.com/*` pages so SPA (soft) navigation into a PR works; formatting only runs on Pull Request pages (`/pull/<number>`)
+- Pages with HCP Terraform (formerly Terraform Cloud) check results — both the new `HCP Terraform/...` and legacy `Terraform Cloud/...` check-name prefixes are supported
 - Compatible with GitHub Enterprise environments
 
 ## 🙏 Acknowledgments
@@ -115,6 +115,13 @@ Special thanks to [github-web-cosmetic](https://github.com/officel/github-web-co
 
 ## 📝 Version History
 
+- **v1.2.0**: Major refactor for maintainability and resilience
+  - Support for the new `HCP Terraform/...` check-name prefix (in addition to legacy `Terraform Cloud/...`)
+  - Text-based detection (TreeWalker) so formatting survives GitHub UI/class-name changes
+  - Works after SPA soft navigation into a PR (content script now injected on all github.com pages)
+  - Rewrites only the smallest element containing the plan summary, preserving sibling controls like "Details"
+  - HTML escaping for injected content; embedded `<script>` JSON payloads are never touched
+- **v1.1.0**: "No changes" plan support with improved formatting
 - **v1.0.1**: Badge feature update with activity indicator
 - **v1.0.0**: Initial release with core formatting features
 - Prefix removal for cleaner workspace names

--- a/background.js
+++ b/background.js
@@ -1,92 +1,39 @@
-// Background script for GitHub HCP Terraform Plan Formatter
-// Handles badge display when extension processes Terraform plans
+// GitHub HCP Terraform Plan Formatter - background service worker
+// Shows a per-tab badge with the number of formatted Terraform plans.
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.type === 'updateBadge') {
-    const tabId = sender.tab.id;
-    const count = message.count;
+const DEFAULT_TITLE = "GitHub HCP Terraform Plan Formatter";
+const BADGE_COLOR = "#4CAF50";
 
-    try {
-      if (count > 0) {
-        // Show badge with count
-        chrome.action.setBadgeText({
-          text: count.toString(),
-          tabId: tabId
-        });
+function updateBadge(tabId, count) {
+  const updates =
+    count > 0
+      ? [
+          chrome.action.setBadgeText({ tabId, text: String(count) }),
+          chrome.action.setBadgeBackgroundColor({ tabId, color: BADGE_COLOR }),
+          chrome.action.setTitle({
+            tabId,
+            title: `${DEFAULT_TITLE} - ${count} plan(s) formatted`,
+          }),
+        ]
+      : [
+          chrome.action.setBadgeText({ tabId, text: "" }),
+          chrome.action.setTitle({ tabId, title: DEFAULT_TITLE }),
+        ];
 
-        // Set badge background color (green for successful processing)
-        chrome.action.setBadgeBackgroundColor({
-          color: '#4CAF50',
-          tabId: tabId
-        });
+  // The tab may have been closed in the meantime; ignore those failures.
+  return Promise.allSettled(updates);
+}
 
-        // Set badge title for tooltip
-        chrome.action.setTitle({
-          title: `GitHub HCP Terraform Plan Formatter - ${count} plan(s) formatted`,
-          tabId: tabId
-        });
-      } else {
-        // Clear badge if no plans processed
-        chrome.action.setBadgeText({
-          text: '',
-          tabId: tabId
-        });
-
-        chrome.action.setTitle({
-          title: 'GitHub HCP Terraform Plan Formatter',
-          tabId: tabId
-        });
-      }
-    } catch (error) {
-      if (error.message.includes('No tab with id')) {
-        console.log(`Tab ${tabId} no longer exists, skipping badge update`);
-      } else {
-        console.error('Error updating badge:', error);
-      }
-    }
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message?.type === "updateBadge" && sender.tab?.id != null) {
+    updateBadge(sender.tab.id, Number(message.count) || 0);
   }
 });
 
-// Clear badge when tab is updated (page navigation)
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.status === 'loading' && tab.url && tab.url.includes('github.com')) {
-    try {
-      chrome.action.setBadgeText({
-        text: '',
-        tabId: tabId
-      });
-
-      chrome.action.setTitle({
-        title: 'GitHub HCP Terraform Plan Formatter',
-        tabId: tabId
-      });
-    } catch (error) {
-      console.log(`Tab ${tabId} no longer exists, skipping badge update`);
-    }
+// Reset the badge whenever the tab starts loading a new page; the content
+// script reports a fresh count once it has formatted anything.
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status === "loading") {
+    updateBadge(tabId, 0);
   }
-});
-
-// Clear badge when tab becomes active
-chrome.tabs.onActivated.addListener(async (activeInfo) => {
-  try {
-    const tab = await chrome.tabs.get(activeInfo.tabId);
-    if (tab.url && !tab.url.includes('github.com')) {
-      chrome.action.setBadgeText({
-        text: '',
-        tabId: activeInfo.tabId
-      });
-    }
-  } catch (error) {
-    if (error.message.includes('No tab with id')) {
-      console.log(`Tab ${activeInfo.tabId} no longer exists, skipping badge clear`);
-    } else {
-      console.error('Error accessing tab:', error);
-    }
-  }
-});
-
-// Clean up when tab is removed
-chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
-  console.log(`Tab ${tabId} was removed, cleaning up`);
-  // Badge will be automatically cleaned up when tab is removed
 });

--- a/content.js
+++ b/content.js
@@ -1,337 +1,333 @@
+// GitHub HCP Terraform Plan Formatter - content script
+//
+// Detects HCP Terraform (formerly Terraform Cloud) status-check titles on
+// GitHub PR pages and reformats them:
+//   "HCP Terraform/<org>/<workspace> — Terraform plan: 1 to add, ..."
+// becomes a two-line, color-coded summary with the org prefix removed.
+//
+// Detection is primarily text-based (TreeWalker over text nodes) so it keeps
+// working when GitHub changes its DOM structure / CSS module class names.
 (function () {
   "use strict";
 
-  let debounceTimer = null;
+  const RESULT_CLASS = "terraform-plan-result";
+  const LINE_CLASS = "terraform-plan-line";
+
+  const PR_PATH_RE = /\/pull\/\d+/;
+
+  // "HCP Terraform/<org>/<workspace>" or legacy "Terraform Cloud/<org>/<workspace>"
+  const PROVIDER_PATH_RE = /(?:HCP Terraform|Terraform Cloud)\/([^/\s]+)\/(\S+)/;
+  const PROVIDER_PREFIX_RE = /(?:HCP Terraform|Terraform Cloud)\/[^/\s]+\//;
+  const PLAN_COUNTS_RE =
+    /Terraform plan:\s*(\d+)\s*to add,\s*(\d+)\s*to change,\s*(\d+)\s*to destroy/;
+  const NO_CHANGES_RE = /no changes/i;
+  const CANDIDATE_TEXT_RE = /Terraform plan|(?:HCP Terraform|Terraform Cloud)\//;
+
+  // Known containers for check titles in past/current GitHub layouts. These
+  // are only cheap hints; the text-node scan below is the primary detection.
+  const KNOWN_SELECTORS = [
+    "div.TimelineItem strong",
+    "span[class*='titleDescription']",
+    "*[class*='StatusCheckRow']",
+  ];
+
+  // Never read from or write into these: GitHub embeds JSON payloads in
+  // <script> tags that also mention check names.
+  const SKIP_TAGS = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "TEMPLATE", "TEXTAREA"]);
+
+  function isSkippedTextNode(node) {
+    const parent = node.parentElement;
+    return !parent || SKIP_TAGS.has(parent.tagName);
+  }
+
+  // textContent of an element excluding script/style/etc. text.
+  function visibleText(el) {
+    if (SKIP_TAGS.has(el.tagName)) return "";
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
+      acceptNode: (node) =>
+        isSkippedTextNode(node)
+          ? NodeFilter.FILTER_REJECT
+          : NodeFilter.FILTER_ACCEPT,
+    });
+    let out = "";
+    while (walker.nextNode()) out += walker.currentNode.data;
+    return out;
+  }
+
+  function escapeHtml(value) {
+    return value.replace(/[&<>"']/g, (c) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    }[c]));
+  }
+
+  // --- Parsing --------------------------------------------------------------
+
+  function extractWorkspaceName(el, text) {
+    // The title attribute of the check link holds the untruncated path, so
+    // prefer it over the (possibly ellipsized) visible text.
+    const link = el.querySelector("a[title]");
+    const sources = [link && link.getAttribute("title"), text];
+    for (const source of sources) {
+      if (!source) continue;
+      const match = source.match(PROVIDER_PATH_RE);
+      if (match) {
+        const name = match[2].replace(/[-—,.\s]+$/, "");
+        if (name) return name;
+      }
+    }
+    return "";
+  }
+
+  // --- Rendering ------------------------------------------------------------
+
+  function renderCount(count, action) {
+    const highlight = count > 0 ? " highlight" : "";
+    const span = `<span class="terraform-count ${action}${highlight}">${count}</span> to ${action}`;
+    return count > 0
+      ? `<span class="terraform-sentence highlight">${span}</span>`
+      : span;
+  }
+
+  function buildResultHtml(workspaceName, href, plan) {
+    const planLine =
+      plan === "no-changes"
+        ? "Terraform plan: No changes"
+        : `Terraform plan: ${renderCount(plan.add, "add")}, ${renderCount(
+            plan.change,
+            "change"
+          )}, ${renderCount(plan.destroy, "destroy")}`;
+
+    let nameLine = "";
+    if (workspaceName) {
+      const escapedName = escapeHtml(workspaceName);
+      const nameHtml = href
+        ? `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${escapedName}</a>`
+        : escapedName;
+      nameLine = `<div class="${LINE_CLASS}">${nameHtml}</div>`;
+    }
+
+    return `<div class="${RESULT_CLASS}">${nameLine}<div class="${LINE_CLASS}">${planLine}</div></div>`;
+  }
+
+  // Shorten "<provider>/<org>/<workspace>" to just the workspace name inside
+  // text nodes, without touching the surrounding markup (links stay intact).
+  function stripProviderPrefix(el) {
+    let changed = false;
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
+      acceptNode: (node) =>
+        isSkippedTextNode(node)
+          ? NodeFilter.FILTER_REJECT
+          : NodeFilter.FILTER_ACCEPT,
+    });
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      if (PROVIDER_PREFIX_RE.test(node.data)) {
+        node.data = node.data.replace(PROVIDER_PREFIX_RE, "");
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  // Descend to the smallest element that still contains the plan summary, so
+  // sibling controls (e.g. the "Details" link in a check row) are preserved.
+  function narrowToSummary(el, summaryRe) {
+    let current = el;
+    for (;;) {
+      const child = Array.from(current.children).find(
+        (c) => !SKIP_TAGS.has(c.tagName) && summaryRe.test(visibleText(c))
+      );
+      if (!child || child.classList.contains(RESULT_CLASS)) break;
+      current = child;
+    }
+    return current;
+  }
+
+  // --- Formatting -----------------------------------------------------------
+
+  function formatElement(el) {
+    if (!el || !el.isConnected) return 0;
+    if (el.dataset.terraformFormatted === "true") return 0;
+    if (el.closest(`.${RESULT_CLASS}`)) return 0;
+    if (el.querySelector(`.${RESULT_CLASS}`)) {
+      el.dataset.terraformFormatted = "true";
+      return 0;
+    }
+
+    const text = visibleText(el);
+    if (!CANDIDATE_TEXT_RE.test(text)) return 0;
+
+    const countsMatch = text.match(PLAN_COUNTS_RE);
+    const hasNoChanges =
+      !countsMatch && /Terraform/.test(text) && NO_CHANGES_RE.test(text);
+
+    if (!countsMatch && !hasNoChanges) {
+      // No plan summary in this element (e.g. the check-title link while the
+      // description lives in a sibling): just drop the long org prefix.
+      // Intentionally not marked as formatted so the element is re-examined
+      // if the plan summary shows up here later.
+      stripProviderPrefix(el);
+      return 0;
+    }
+
+    const workspaceName = extractWorkspaceName(el, text);
+    const target = narrowToSummary(el, countsMatch ? PLAN_COUNTS_RE : NO_CHANGES_RE);
+    if (target.dataset.terraformFormatted === "true") return 0;
+
+    // Only render the workspace line when its name actually lives inside the
+    // element being rewritten; otherwise it stays visible as a sibling (which
+    // stripProviderPrefix below cleans up) and rendering it twice looks odd.
+    const targetText = visibleText(target);
+    const nameInTarget =
+      PROVIDER_PATH_RE.test(targetText) ||
+      !!target.querySelector("a[title*='Terraform']");
+    const innerLink = target.querySelector("a[href]");
+    const href = innerLink ? innerLink.getAttribute("href") : "";
+
+    const plan = countsMatch
+      ? {
+          add: parseInt(countsMatch[1], 10),
+          change: parseInt(countsMatch[2], 10),
+          destroy: parseInt(countsMatch[3], 10),
+        }
+      : "no-changes";
+
+    target.innerHTML = buildResultHtml(
+      nameInTarget ? workspaceName : "",
+      href,
+      plan
+    );
+    target.style.display = "block";
+    target.style.whiteSpace = "normal";
+    target.dataset.terraformFormatted = "true";
+
+    if (target !== el) {
+      stripProviderPrefix(el);
+    }
+    return 1;
+  }
+
+  // --- Candidate discovery ----------------------------------------------------
+
+  // Climb to the outermost wrapper with identical text so a link and its inner
+  // spans are handled as one unit.
+  function containerFor(el) {
+    let current = el;
+    while (
+      current.parentElement &&
+      current.parentElement !== document.body &&
+      current.parentElement.textContent.trim() === current.textContent.trim()
+    ) {
+      current = current.parentElement;
+    }
+    return current;
+  }
+
+  function collectCandidates() {
+    const candidates = new Set();
+
+    // Known layouts first: these containers may hold both the check-title
+    // link and the plan description, giving the best formatting result.
+    for (const selector of KNOWN_SELECTORS) {
+      for (const el of document.querySelectorAll(selector)) {
+        if (CANDIDATE_TEXT_RE.test(el.textContent || "")) {
+          candidates.add(el);
+        }
+      }
+    }
+
+    // Selector-independent fallback: any text node mentioning a Terraform
+    // plan or a provider path, wherever GitHub happens to render it.
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+      acceptNode: (node) =>
+        !isSkippedTextNode(node) && CANDIDATE_TEXT_RE.test(node.data)
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_REJECT,
+    });
+    while (walker.nextNode()) {
+      const parent = walker.currentNode.parentElement;
+      if (!parent || parent.closest(`.${RESULT_CLASS}`)) continue;
+      candidates.add(containerFor(parent));
+    }
+
+    return candidates;
+  }
+
+  // --- Main loop ----------------------------------------------------------------
+
+  let totalFormatted = 0;
 
   function formatTerraformResults() {
-
-    const ciCheckTitleSelectors = [
-      "div.TimelineItem strong",
-      "ul li div a span",
-      "span[class*='titleDescription']",
-      "*[class*='StatusCheckRow']",
-    ];
+    if (!PR_PATH_RE.test(location.pathname)) return;
 
     let processed = 0;
+    for (const el of collectCandidates()) {
+      processed += formatElement(el);
+    }
 
-    ciCheckTitleSelectors.forEach((selector) => {
-      const elements = document.querySelectorAll(selector);
-      elements.forEach((el) => {
-        // Skip if already processed or if it's a terraform-plan-result element
-        // BUT re-process if it contains "Terraform Workspace" (incorrect formatting)
-        if ((el.dataset.terraformFormatted === 'true' || el.classList.contains('terraform-plan-result')) && 
-            !el.textContent.includes('Terraform Workspace')) {
-          return;
-        }
-
-        // Skip if this element contains a terraform-plan-result (already processed by a child)
-        if (el.querySelector('.terraform-plan-result')) {
-          return;
-        }
-
-        // Skip if parent element already has terraform-plan-result
-        if (el.closest('.terraform-plan-result')) {
-          return;
-        }
-
-        if (el.textContent && (el.textContent.includes('Terraform plan:') || el.textContent.includes('Terraform Cloud/') || el.textContent.includes('No changes') || el.textContent.includes('Terraform plan has no changes'))) {
-          let text = el.textContent;
-          const originalHTML = el.innerHTML;
-
-          // Extract workspace name more carefully
-          let workspaceDisplayName = '';
-
-          // First try to extract from HTML if it contains a link
-          if (originalHTML.includes('Terraform Cloud/')) {
-            // Try to extract from span elements or link text
-            const spanMatch = originalHTML.match(/<span[^>]*>Terraform Cloud\/([^/]+)\/([^<]+)<\/span>/);
-            const linkTextMatch = originalHTML.match(/Terraform Cloud\/([^/]+)\/([^<>"'\s,]+)/);
-
-            if (spanMatch && spanMatch[2]) {
-              workspaceDisplayName = spanMatch[2].trim();
-            } else if (linkTextMatch && linkTextMatch[2]) {
-              workspaceDisplayName = linkTextMatch[2].trim();
-            }
-          }
-
-          // If not found in HTML, try text patterns
-          if (!workspaceDisplayName) {
-            // Try multiple patterns to extract workspace name
-            const patterns = [
-              /Terraform Cloud\/([^/]+)\/([^/\s\-—\r\n]+)/,  // More precise pattern to avoid separators
-              /Terraform Cloud\/([^/]+)\/(.+?)(?=\s*[-—]|\s*Terraform plan:|\s*$)/,
-              /Terraform Cloud\/[^/]+\/([^/\s\-—\r\n]+)/
-            ];
-
-            for (const pattern of patterns) {
-              const match = text.match(pattern);
-              if (match) {
-                // Use the last capture group that contains the workspace name
-                workspaceDisplayName = (match[2] || match[1]).trim();
-                // Additional cleanup: remove any trailing separators or whitespace
-                workspaceDisplayName = workspaceDisplayName.replace(/[-—\s]+$/, '').trim();
-
-                // Validate that the workspace name is not empty or just separators
-                if (workspaceDisplayName && !/^[-—\s]*$/.test(workspaceDisplayName)) {
-                  break;
-                } else {
-                  workspaceDisplayName = '';
-                }
-              }
-            }
-          }
-
-          // If still no workspace name, try a simpler extraction
-          if (!workspaceDisplayName && text.includes('Terraform Cloud/')) {
-            const parts = text.split('Terraform Cloud/')[1];
-            if (parts) {
-              const pathParts = parts.split('/');
-              if (pathParts.length >= 2) {
-                workspaceDisplayName = pathParts.slice(1).join('/').split(/\s+/)[0];
-                // Remove any separators
-                workspaceDisplayName = workspaceDisplayName.replace(/[-—\s]+.*$/, '');
-              }
-            }
-          }
-
-          // Final check: make sure workspace name is not just a separator or invalid
-          if (workspaceDisplayName && (/^[-—\s]*$/.test(workspaceDisplayName) || workspaceDisplayName === '—')) {
-            workspaceDisplayName = '';
-          }
-
-          // If we still don't have a valid workspace name, try to extract from title attribute
-          if (!workspaceDisplayName && originalHTML.includes('title=')) {
-            const titleMatch = originalHTML.match(/title="([^"]*Terraform Cloud\/[^/]+\/[^"]*?)"/);
-            if (titleMatch) {
-              const titleContent = titleMatch[1];
-              const titleWorkspaceMatch = titleContent.match(/Terraform Cloud\/[^/]+\/([^\s]+)/);
-              if (titleWorkspaceMatch && titleWorkspaceMatch[1]) {
-                workspaceDisplayName = titleWorkspaceMatch[1].trim();
-              }
-            }
-          }
-
-          // Replace the full Terraform Cloud path with just the workspace name
-          if (workspaceDisplayName) {
-            // Remove the entire original Terraform Cloud line and any separators
-            text = text.replace(/Terraform Cloud\/[^/]+\/[^\r\n]*[-—\s]*\r?\n?/g, '');
-            text = text.replace(/^[-—\s]*\r?\n?/gm, ''); // Remove separator lines
-            text = text.trim();
-          }
-
-          const planMatch = text.match(/Terraform plan:\s*(\d+)\s*to add,\s*(\d+)\s*to change,\s*(\d+)\s*to destroy/);
-          const noChangesMatch = text.match(/Terraform plan:\s*No changes/) || text.match(/No changes/) || text.match(/Terraform plan has no changes/);
-          
-          // Check if this is a processed workspace name that needs "No changes" formatting
-          const isProcessedWorkspace = text.includes('Terraform Cloud/') && !text.includes('Terraform plan:') && !text.includes('to add') && !text.includes('to change') && !text.includes('to destroy');
-          
-          // Check if this is a titleDescription element with "Terraform plan has no changes"
-          const isTitleDescriptionNoChanges = text.includes('Terraform plan has no changes') && (el.classList.contains('titleDescription') || el.className.includes('titleDescription'));
-
-          if (planMatch) {
-            const [, add, change, destroy] = planMatch;
-
-            // Completely replace the element content to avoid showing original text
-            el.style.display = 'block';
-
-            if (originalHTML.includes('<a ') && originalHTML.includes('href=')) {
-
-              const createColoredSentence = (count, type, action) => {
-                const num = parseInt(count);
-                const highlightClass = num > 0 ? ' highlight' : '';
-                const countSpan = `<span class="terraform-count ${type}${highlightClass}">${count}</span>`;
-
-                if (num > 0) {
-                  return `<span class="terraform-sentence highlight">${countSpan} to ${action}</span>`;
-                } else {
-                  return `${countSpan} to ${action}`;
-                }
-              };
-
-              const coloredAdd = createColoredSentence(add, 'add', 'add');
-              const coloredChange = createColoredSentence(change, 'change', 'change');
-              const coloredDestroy = createColoredSentence(destroy, 'destroy', 'destroy');
-
-
-              const linkMatch = originalHTML.match(/<a[^>]*href="[^"]*"[^>]*>.*?<\/a>/s);
-              let workspaceLink = '';
-
-              if (linkMatch) {
-
-
-                const titleMatch = linkMatch[0].match(/title="([^"]*)"/);
-                const hrefMatch = linkMatch[0].match(/href="([^"]*)"/);
-
-                if (titleMatch && hrefMatch) {
-                  const titleContent = titleMatch[1];
-
-                  // Extract workspace name from title more carefully
-                  const workspaceMatch = titleContent.match(/Terraform Cloud\/([^/]+)\/(.+?)(?:\s+[-—]?\s*Terraform plan:|$)/);
-                  if (workspaceMatch) {
-                    const cleanWorkspace = workspaceMatch[2].trim();
-                    workspaceLink = `<a href="${hrefMatch[1]}" target="_blank">${cleanWorkspace}</a>`;
-                  } else {
-                    // Fallback: use the workspace name we extracted earlier
-                    const cleanWorkspace = workspaceDisplayName || text.substring(0, text.indexOf('Terraform plan:')).trim();
-                    workspaceLink = `<a href="${hrefMatch[1]}" target="_blank">${cleanWorkspace}</a>`;
-                  }
-                }
-              }
-
-              const finalHTML = `<div class="terraform-plan-line">${workspaceLink || 'Terraform Workspace'}</div><div class="terraform-plan-line">Terraform plan: ${coloredAdd}, ${coloredChange}, ${coloredDestroy}</div>`;
-
-              // Clear existing content and set new content
-              el.innerHTML = '';
-              el.innerHTML = `<div class="terraform-plan-result">${finalHTML}</div>`;
-              el.style.whiteSpace = 'normal';
-              processed++;
-            } else {
-              // For non-link elements, use the extracted workspace name
-              const workspaceName = workspaceDisplayName || text.substring(0, text.indexOf('Terraform plan:')).trim();
-
-              const createColoredSentence = (count, type, action) => {
-                const num = parseInt(count);
-                const highlightClass = num > 0 ? ' highlight' : '';
-                const countSpan = `<span class="terraform-count ${type}${highlightClass}">${count}</span>`;
-
-                if (num > 0) {
-                  return `<span class="terraform-sentence highlight">${countSpan} to ${action}</span>`;
-                } else {
-                  return `${countSpan} to ${action}`;
-                }
-              };
-
-              const coloredAdd = createColoredSentence(add, 'add', 'add');
-              const coloredChange = createColoredSentence(change, 'change', 'change');
-              const coloredDestroy = createColoredSentence(destroy, 'destroy', 'destroy');
-
-              const coloredHTML = `<div class="terraform-plan-result">${workspaceName && workspaceName.length > 0 ? `<div class="terraform-plan-line">${workspaceName}</div>` : `<div class="terraform-plan-line">Terraform Workspace</div>`}<div class="terraform-plan-line">Terraform plan: ${coloredAdd}, ${coloredChange}, ${coloredDestroy}</div></div>`;
-
-              // Clear existing content and set new content
-              el.innerHTML = '';
-              el.innerHTML = coloredHTML;
-              el.style.whiteSpace = 'normal';
-              processed++;
-            }
-          } else if (noChangesMatch) {
-            // Handle "No changes" case
-            el.style.display = 'block';
-
-            if (originalHTML.includes('<a ') && originalHTML.includes('href=')) {
-              const linkMatch = originalHTML.match(/<a[^>]*href="[^"]*"[^>]*>.*?<\/a>/s);
-              let workspaceLink = '';
-
-              if (linkMatch) {
-                const titleMatch = linkMatch[0].match(/title="([^"]*)"/);
-                const hrefMatch = linkMatch[0].match(/href="([^"]*)"/);
-
-                if (titleMatch && hrefMatch) {
-                  const titleContent = titleMatch[1];
-                  const workspaceMatch = titleContent.match(/Terraform Cloud\/([^/]+)\/(.+?)(?:\s+[-—]?\s*Terraform plan:|$)/);
-                  if (workspaceMatch) {
-                    const cleanWorkspace = workspaceMatch[2].trim();
-                    workspaceLink = `<a href="${hrefMatch[1]}" target="_blank">${cleanWorkspace}</a>`;
-                  } else {
-                    const cleanWorkspace = workspaceDisplayName || text.substring(0, text.indexOf('Terraform plan:')).trim();
-                    workspaceLink = `<a href="${hrefMatch[1]}" target="_blank">${cleanWorkspace}</a>`;
-                  }
-                }
-              }
-
-              const finalHTML = `<div class="terraform-plan-line">${workspaceLink || 'Terraform Workspace'}</div><div class="terraform-plan-line">Terraform plan: No changes</div>`;
-              el.innerHTML = '';
-              el.innerHTML = `<div class="terraform-plan-result">${finalHTML}</div>`;
-              el.style.whiteSpace = 'normal';
-              processed++;
-            } else {
-              const workspaceName = workspaceDisplayName || text.substring(0, text.indexOf('Terraform plan:')).trim();
-              const noChangesHTML = `<div class="terraform-plan-result">${workspaceName && workspaceName.length > 0 ? `<div class="terraform-plan-line">${workspaceName}</div>` : `<div class="terraform-plan-line">Terraform Workspace</div>`}<div class="terraform-plan-line">Terraform plan: No changes</div></div>`;
-              
-              el.innerHTML = '';
-              el.innerHTML = noChangesHTML;
-              el.style.whiteSpace = 'normal';
-              processed++;
-            }
-          } else if (isProcessedWorkspace) {
-            // This is a processed workspace name that should have "No changes" formatting
-            // Display workspace name with "—" and "Terraform plan: No changes"
-            el.style.display = 'block';
-            const workspaceName = text.replace(/^Terraform Cloud\/[^/]+\//, '');
-            const finalHTML = `<div class="terraform-plan-line">${workspaceName}</div><div class="terraform-plan-line">—</div><div class="terraform-plan-line">Terraform plan: No changes</div>`;
-            el.innerHTML = `<div class="terraform-plan-result">${finalHTML}</div>`;
-            el.style.whiteSpace = 'normal';
-            processed++;
-          } else if (isTitleDescriptionNoChanges) {
-            // This is a titleDescription element with "Terraform plan has no changes"
-            // Display only "— Terraform plan: No changes" without workspace name
-            el.style.display = 'block';
-            const finalHTML = `<div class="terraform-plan-line">— Terraform plan: No changes</div>`;
-            el.innerHTML = `<div class="terraform-plan-result">${finalHTML}</div>`;
-            el.style.whiteSpace = 'normal';
-            processed++;
-          }
-
-          el.dataset.terraformFormatted = 'true';
-        }
-      });
-    });
-
-    // Fix any remaining "Terraform Workspace" displays
-    document.querySelectorAll('.terraform-plan-result').forEach(planResult => {
-      if (planResult.textContent.includes('Terraform Workspace')) {
-        const lines = planResult.querySelectorAll('.terraform-plan-line');
-        
-        // Find and fix the "Terraform Workspace" line
-        lines.forEach(line => {
-          if (line.textContent === 'Terraform Workspace') {
-            line.textContent = '—';
-            processed++;
-          }
-        });
-      }
-    });
-
-    // Send message to background script to update badge
     if (processed > 0) {
-      chrome.runtime.sendMessage({
-        type: 'updateBadge',
-        count: processed
+      totalFormatted += processed;
+      console.debug(
+        `🎯 Terraform Plan Formatter: formatted ${processed} element(s)`
+      );
+      reportProcessed(totalFormatted);
+    }
+  }
+
+  function reportProcessed(count) {
+    try {
+      chrome.runtime.sendMessage({ type: "updateBadge", count }, () => {
+        // Read lastError so Chrome doesn't log "Unchecked runtime.lastError"
+        // when the service worker is asleep or the extension was reloaded.
+        void chrome.runtime.lastError;
       });
+    } catch {
+      // Extension context invalidated (extension updated/reloaded); ignore.
     }
-
   }
 
-  function handlePageLoadOrTransition() {
-    formatTerraformResults();
+  let debounceTimer = null;
+
+  function scheduleFormat(delay = 200) {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(formatTerraformResults, delay);
   }
 
-  document.addEventListener("turbo:load", handlePageLoadOrTransition);
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", handlePageLoadOrTransition);
-  } else {
-    handlePageLoadOrTransition();
-  }
-
+  // The script is injected on all github.com pages so it also works when the
+  // user soft-navigates (Turbo/SPA) into a PR; formatTerraformResults() bails
+  // out cheaply on non-PR URLs.
   let lastUrl = location.href;
-  const observer = new MutationObserver(() => {
-    const currentUrl = location.href;
-    if (currentUrl !== lastUrl) {
-      lastUrl = currentUrl;
-      setTimeout(handlePageLoadOrTransition, 300);
-    } else {
-      clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(formatTerraformResults, 150);
+  const observer = new MutationObserver((mutations) => {
+    if (location.href !== lastUrl) {
+      lastUrl = location.href;
+      totalFormatted = 0;
+      scheduleFormat(300);
+      return;
     }
+    const relevant = mutations.some((m) => {
+      const t = m.target;
+      return !(
+        t instanceof Element &&
+        (t.dataset.terraformFormatted === "true" ||
+          t.closest(`.${RESULT_CLASS}`))
+      );
+    });
+    if (relevant) scheduleFormat();
   });
-  observer.observe(document.body, { childList: true, subtree: true });
 
-  document.body.addEventListener("click", function (event) {
-    const potentialButton = event.target.closest(
-      'button, summary, [role="button"]'
-    );
+  function start() {
+    formatTerraformResults();
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
 
-    if (potentialButton) {
-      setTimeout(formatTerraformResults, 300);
-    }
-  });
+  document.addEventListener("turbo:load", () => scheduleFormat(100));
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start);
+  } else {
+    start();
+  }
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GitHub HCP Terraform Plan Formatter",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Formats HCP Terraform plan results on GitHub PR pages by removing org prefixes and showing simplified add/change/destroy counts",
   "icons": {
     "16": "icons/icon16.png",
@@ -30,7 +30,7 @@
   ],
   "content_scripts": [
     {
-      "matches": ["*://github.com/*/pull/*"],
+      "matches": ["*://github.com/*"],
       "js": ["content.js"],
       "css": ["style.css"],
       "run_at": "document_idle"

--- a/style.css
+++ b/style.css
@@ -87,21 +87,3 @@ div.TimelineItem strong .terraform-plan-result {
   max-width: none !important;
 }
 
-/* Edge ブラウザ対応 */
-@supports (-ms-ime-align: auto) {
-  .terraform-plan-result {
-    display: block !important;
-  }
-
-  .terraform-plan-line {
-    display: block !important;
-    clear: both !important;
-  }
-}
-
-/* 追加の強制表示対応 */
-.terraform-plan-line:empty::before {
-  content: "Terraform Workspace";
-  color: #666;
-  font-style: italic;
-}


### PR DESCRIPTION
## Summary

Major refactor of the content/background scripts for maintainability, plus fixes for several cases where the extension silently stopped working due to GitHub / HCP Terraform changes.

### Functional fixes

- **`HCP Terraform/` prefix support** — the old code only matched the pre-rebrand `Terraform Cloud/` prefix, so current HCP Terraform checks were never formatted. Both prefixes are now supported.
- **SPA soft-navigation fix** — the content script was only injected on `*/pull/*`, so navigating into a PR via Turbo soft navigation (e.g. from the repo top page) meant the script was never loaded. It is now injected on all `github.com` pages and gates execution by URL at runtime.
- **Resilience to GitHub UI changes** — detection is now primarily a TreeWalker text-node scan instead of CSS-module class-name selectors, so it survives markup changes like the React-based merge box. Known selectors are kept as cheap hints.
- **"Details" link destruction fix** — the old code replaced the innerHTML of entire `StatusCheckRow` elements, wiping sibling controls. Now only the smallest element containing the plan summary is rewritten.
- **Embedded JSON protection** — `<script>`/`<style>` text is excluded from both detection and rewriting, so GitHub's embedded JSON payloads (which also mention check names) can no longer be corrupted.
- **HTML escaping** for all strings injected into the page.

### Maintainability

- `content.js`: duplicated logic (color renderer defined twice, 4 near-identical branches) split into small parse/render/detect helpers; regex-based HTML parsing replaced with DOM APIs.
- `background.js`: badge handling consolidated into one helper; the old `try/catch` never caught async `chrome.action` failures — replaced with `Promise.allSettled`. Removed two no-op listeners.
- `style.css`: removed dead EdgeHTML (`-ms-ime-align`) hack and the `:empty::before` placeholder hack.
- Version bumped to 1.2.0; README / CLAUDE.md updated to match the new architecture.

## Test plan

- [x] `node --check content.js background.js`
- [x] Browser-verified against a GitHub-like fixture served under `/owner/repo/pull/123`:
  - legacy TimelineItem layout (link + summary in one `<strong>`)
  - new layout with the check-title link and description as siblings
  - "no changes" variants
  - "Details" link preserved in a StatusCheckRow
  - unrelated "No changes" text left untouched
  - embedded JSON `<script>` left untouched (still parses)
  - dynamically inserted check row (MutationObserver)
  - idempotency: repeated passes cause no DOM churn / infinite loop
- [x] Manual check on a real PR with HCP Terraform checks after loading the unpacked extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)